### PR TITLE
Update test_model.py

### DIFF
--- a/test_model.py
+++ b/test_model.py
@@ -94,8 +94,10 @@ def main():
     # Takes more time at startup, but optimizes runtime.
     torch.backends.cudnn.benchmark = True
 
-    args = parse_args()
-    reserve_gpu(args.gpu)
+    if args.gpu is None:
+    args.gpu = reserve_gpu()  # Automatically selects the least busy GPU.
+    elif not torch.cuda.is_available():
+    print("CUDA is not available. Running on CPU.")
 
     defense_config = mlconfig.load(args.wm_config)
     print(defense_config)


### PR DESCRIPTION
Title: Improve reserve_gpu to Handle Unavailable or Busy GPUs Problem Statement:
The current implementation of the reserve_gpu function assumes that the provided GPU is always available. However, this is not guaranteed, especially in shared environments where GPUs may already be in use or unavailable. If the specified GPU cannot be allocated, the script may fail silently or crash without providing a fallback mechanism.

Proposed Solution:

Add a Fallback Mechanism: Modify the reserve_gpu function to:

Check GPU availability using torch.cuda.memory_reserved() or nvidia-smi (if accessible). If the specified GPU is unavailable, attempt to select another GPU with the least memory utilization. If no GPUs are available, default to CPU mode with a user notification.